### PR TITLE
Windows

### DIFF
--- a/build.go
+++ b/build.go
@@ -36,6 +36,10 @@ func (b *Build) Build() error {
 		return nil
 	}
 
+	// convert any paths to the correct format for the OS
+	b.BuildCmd = filepath.FromSlash(b.BuildCmd)
+	b.BuildDir = filepath.FromSlash(b.BuildDir)
+
 	slog.Info("build execute", "name", b.Name, "buildDir", b.BuildDir, "buildCmd", b.BuildCmd, "buildArgs", b.BuildArgs, "buildEnv", b.BuildEnv)
 
 	start := time.Now()
@@ -71,6 +75,10 @@ func (b *Build) Run(ctx context.Context) {
 		slog.Warn("runCmd not defined", "name", b.Name, "runCmd", b.RunCmd)
 		return
 	}
+
+	// convert any paths to the correct format for the OS
+	b.RunCmd = filepath.FromSlash(b.RunCmd)
+	b.RunDir = filepath.FromSlash(b.RunDir)
 
 	slog.Info("run execute", "name", b.Name, "runDir", b.RunDir, "runCmd", b.RunCmd, "runArgs", b.RunArgs, "runEnv", b.RunEnv)
 

--- a/build.go
+++ b/build.go
@@ -31,6 +31,11 @@ type Build struct {
 // ex: err := b.Build()
 func (b *Build) Build() error {
 
+	if b.BuildCmd == "" {
+		slog.Warn("buildCmd not defined", "name", b.Name, "buildCmd", b.BuildCmd)
+		return nil
+	}
+
 	slog.Info("build execute", "name", b.Name, "buildDir", b.BuildDir, "buildCmd", b.BuildCmd, "buildArgs", b.BuildArgs, "buildEnv", b.BuildEnv)
 
 	start := time.Now()
@@ -61,6 +66,11 @@ func (b *Build) Build() error {
 //
 // ex: b.Run(ctx)
 func (b *Build) Run(ctx context.Context) {
+
+	if b.RunCmd == "" {
+		slog.Warn("runCmd not defined", "name", b.Name, "runCmd", b.RunCmd)
+		return
+	}
 
 	slog.Info("run execute", "name", b.Name, "runDir", b.RunDir, "runCmd", b.RunCmd, "runArgs", b.RunArgs, "runEnv", b.RunEnv)
 
@@ -102,6 +112,7 @@ func (b *Build) Start(parentContext context.Context, restart chan struct{}) {
 		if err != nil {
 			slog.Error("watch", "name", b.Name, "error", err)
 			<-restart // block until the watcher says something changed
+			continue  // retry the build before moving on to running
 		}
 
 		runContext, runCancel := context.WithCancel(parentContext)

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 	"time"
 )
@@ -44,10 +45,15 @@ func NewConfig() *Config {
 //
 //	ex: myConfig.Save("go-live-reload.json")
 func (c *Config) Save(filename string) error {
+
+	// convert any paths to the correct format for the OS
+	filename = filepath.FromSlash(filename)
+
 	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return err
 	}
+
 	err = os.WriteFile(filename, data, 0644)
 	if err != nil {
 		return err
@@ -59,10 +65,15 @@ func (c *Config) Save(filename string) error {
 //
 //	ex: myConfig.Load("go-live-reload.json")
 func (c *Config) Load(filename string) error {
+
+	// convert any paths to the correct format for the OS
+	filename = filepath.FromSlash(filename)
+
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
+
 	err = json.Unmarshal(data, c)
 	if err != nil {
 		return err


### PR DESCRIPTION
These changes will allow Go at runtime to decide what the best path seperator to use should be. It runs each `buildCmd`, `buildArgs`, `runCmd`, `runArgs`, `load-config` and `save-config` through before attempting to use them. The match function was already OS independent.

Piggybacking on this PR is a minor correction to build=>error handling in that it should not attempt to run until a build passes, blocked until watch signals a restart.

Finally, build and run will now return early if the command to execute is blank but it doesn't error. I think this is closer to the least surprise principle and allows users to effectively skip that step for edge cases.

On Windows, with the following config file, (mywebserver's linux config) it parsed cleanly.

- fixes #5 

```
PS D:\tmp\mywebserver> go tool go-live-reload --config-file .\.config\go-live-reload.json --log-level debug --overwrite-heartbeat 5s
2025/02/26 05:16:47 WARN overwrite-heartbeat duration=5s
2025/02/26 05:16:47 WARN no build-groups defined, defaulting to all
2025/02/26 05:16:47 INFO ready config-file=.\.config\go-live-reload.json
2025/02/26 05:16:47 INFO entering run loop count=1
2025/02/26 05:16:47 INFO watch start name=www match="[*.go embeded/template/* embeded/wwwroot/* embeded/wwwroot/*/*]"
2025/02/26 05:16:47 INFO build execute name=www buildDir=. buildCmd=go buildArgs="[build -o build/mywebserver]" buildEnv=[]
2025/02/26 05:16:47 DEBUG watch match=main.go
2025/02/26 05:16:47 DEBUG watch match=embeded\template\version.html
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\css
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\index.html
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\js
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\sse.html
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\websockets.html
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\css\style.css
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\js\sse.js
2025/02/26 05:16:47 DEBUG watch match=embeded\wwwroot\js\ws.js
2025/02/26 05:16:48 INFO build success name=www duration=531.326ms
2025/02/26 05:16:48 INFO run execute name=www runDir=build runCmd=.\mywebserver runArgs="[--bind :8081]" runEnv="[SECRET=friend]"
2025/02/26 05:16:48 INFO http server listening bind=:8081
2025/02/26 05:16:50 INFO interrupt signal received
2025/02/26 05:16:50 WARN shutdown signaled name=www
2025/02/26 05:16:50 INFO http server stopped
2025/02/26 05:16:50 INFO server stopped
```

```json
{
  "name": "github.com/dearing/go-live-reload",
  "description": "example config",
  "builds": [
    {
      "name": "www",
      "description": "frontend webserver",
      "match": [
        "*.go",
        "embeded/template/*",
        "embeded/wwwroot/*",
        "embeded/wwwroot/*/*"
      ],
      "heartBeat": 1000000000,
      "buildCmd": "go",
      "buildArgs": [
        "build",
        "-o",
        "build/mywebserver"
      ],
      "buildDir": ".",
      "runCmd": "./mywebserver",
      "runArgs": [
        "--bind",
        ":8081"
      ],
      "runDir": "build",
      "runEnv": [
        "SECRET=friend"
      ]
    }
  ]
}
```